### PR TITLE
開催数の数値を入力するフォームをmaterial uiに置き換える

### DIFF
--- a/frontend/src/component/NotificationFormTweetAndDiscordAndCharender.tsx
+++ b/frontend/src/component/NotificationFormTweetAndDiscordAndCharender.tsx
@@ -1,3 +1,4 @@
+import { TextField as MuiTextField } from "@material-ui/core";
 import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { Checkbox } from "@mui/material";
@@ -12,6 +13,11 @@ export const NotificationFormTweetAndDiscordAndCharender = () => {
         method="POST"
         action="http://localhost:3001/post_announcement"
       >
+        <MuiTextField
+          type="number"
+          name="numberOfSessions"
+          variant="outlined"
+        />
         <LocalizationProvider dateAdapter={AdapterDayjs}>
           <DatePicker />
         </LocalizationProvider>


### PR DESCRIPTION
## やったこと

- 開催数の数値を入力するフォームをmaterial uiに置き換える

## とくに見て欲しいところ

- 特になし

## 動作確認したこと

- 特になし
