### PR TITLE
イベント名の入力フォームのonChangeの指定方法を変える

### DIFF
--- a/frontend/src/component/VrcEventCalenderUrlGenerator/Form/EventName.tsx
+++ b/frontend/src/component/VrcEventCalenderUrlGenerator/Form/EventName.tsx
@@ -7,7 +7,7 @@ import { ChangeEventHandler } from "react";
 
 type Props = {
   value: string;
-  onChange: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+  onChange: () => ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>;
 };
 
 export const EventName = ({ value, onChange }: Props) => {
@@ -18,7 +18,7 @@ export const EventName = ({ value, onChange }: Props) => {
         name="eventName"
         variant="outlined"
         value={value}
-        onChange={onChange}
+        onChange={onChange()}
       />
     </MuiFormControl>
   );

--- a/frontend/src/component/VrcEventCalenderUrlGenerator/index.tsx
+++ b/frontend/src/component/VrcEventCalenderUrlGenerator/index.tsx
@@ -70,7 +70,7 @@ export const VrcEventCalenderUrlGenerator = () => {
       <MuiFormGroup>
         <EventName
           value={formik.values.eventName}
-          onChange={formik.handleChange}
+          onChange={() => formik.handleChange}
         />
         <AvelablePlatform
           initialValue={formik.values.avelablePlatform}


### PR DESCRIPTION
## やったこと

- イベント名の入力フォームのonChangeの指定方法を変える

## とくに見て欲しいところ

- 特になし

## 動作確認したこと

- フォームが動作することを確認した
