### PR TITLE
イベント主催者の入力フォームのonChangeの指定方法を変える

### DIFF
--- a/frontend/src/component/VrcEventCalenderUrlGenerator/Form/EventOwner.tsx
+++ b/frontend/src/component/VrcEventCalenderUrlGenerator/Form/EventOwner.tsx
@@ -7,7 +7,7 @@ import { ChangeEventHandler } from "react";
 
 type Props = {
   eventOwner: string;
-  onChange: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+  onChange: () => ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>;
 };
 
 export const EventOwner = ({ eventOwner, onChange }: Props) => {
@@ -17,7 +17,7 @@ export const EventOwner = ({ eventOwner, onChange }: Props) => {
       <MuiTextField
         name="eventOwner"
         variant="outlined"
-        onChange={onChange}
+        onChange={onChange()}
         value={eventOwner}
       />
     </MuiFormControl>

--- a/frontend/src/component/VrcEventCalenderUrlGenerator/index.tsx
+++ b/frontend/src/component/VrcEventCalenderUrlGenerator/index.tsx
@@ -102,7 +102,7 @@ export const VrcEventCalenderUrlGenerator = () => {
         />
         <EventOwner
           eventOwner={formik.values.eventOwner}
-          onChange={formik.handleChange}
+          onChange={() => formik.handleChange}
         />
         <EventContent
           eventContent={formik.values.evnetContent}


### PR DESCRIPTION
## やったこと

- イベント主催者の入力フォームのonChangeの指定方法を変える

## とくに見て欲しいところ

- 特になし

## 動作確認したこと

- 入力フォームが動作することを確認
