### PR TITLE
イベント内容の入力フォームのonChangeの指定方法を変える

### DIFF
--- a/frontend/src/component/VrcEventCalenderUrlGenerator/Form/EventContent.tsx
+++ b/frontend/src/component/VrcEventCalenderUrlGenerator/Form/EventContent.tsx
@@ -7,7 +7,7 @@ import { ChangeEventHandler } from "react";
 
 type Props = {
   eventContent: string;
-  onChange: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+  onChange: () => ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>;
 };
 
 export const EventContent = ({ eventContent, onChange }: Props) => {
@@ -17,7 +17,7 @@ export const EventContent = ({ eventContent, onChange }: Props) => {
       <MuiTextField
         name="evnetContent"
         variant="outlined"
-        onChange={onChange}
+        onChange={onChange()}
         value={eventContent}
       />
     </MuiFormControl>

--- a/frontend/src/component/VrcEventCalenderUrlGenerator/index.tsx
+++ b/frontend/src/component/VrcEventCalenderUrlGenerator/index.tsx
@@ -106,7 +106,7 @@ export const VrcEventCalenderUrlGenerator = () => {
         />
         <EventContent
           eventContent={formik.values.evnetContent}
-          onChange={formik.handleChange}
+          onChange={() => formik.handleChange}
         />
         <EventGenre
           initialValue={formik.values.eventGenre}


### PR DESCRIPTION
## やったこと

- イベント内容の入力フォームのonChangeの指定方法を変える

## とくに見て欲しいところ

- 特になし

## 動作確認したこと

- フォームが動作することを確認
