### PR TITLE
yarn startコマンドでbackendとfrontendが同時起動するようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "yuni-0928 <yuniyuni0928@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "start": "yarn start:backend & yarn start:frontend",
+    "start": "yarn run npm-run-all -p -r start:backend start:frontend",
     "start:backend": "cd backend && yarn start",
     "start:frontend": "cd frontend && yarn dev"
   },


### PR DESCRIPTION
## やったこと

- npm-run-allを使ってyarn startコマンドでbackendとfrontendが同時起動するようにする

## とくに見て欲しいところ

- 特になし

## 動作確認したこと

- frontとbackが同時起動して、ctl + cで問題なく両方ともシャットダウンできることを確認しました
