### PR TITLE
dateの型をstringに変更

### DIFF
--- a/frontend/src/component/VrcEventCalenderUrlGenerator/index.tsx
+++ b/frontend/src/component/VrcEventCalenderUrlGenerator/index.tsx
@@ -23,7 +23,7 @@ export const VrcEventCalenderUrlGenerator = () => {
   const initialValues: VrcEventCalenderType = {
     eventName: "エンジニア作業飲み集会",
     availablePlatform: "PC&Quest",
-    date: dayjs(),
+    date: dayjs().format("YYYY-MM-DD"),
     startTime: "22:00",
     endTime: "23:30",
     eventOwner: "慕狼ゆに",

--- a/frontend/src/component/VrcEventCalenderUrlGenerator/parts/Date.tsx
+++ b/frontend/src/component/VrcEventCalenderUrlGenerator/parts/Date.tsx
@@ -7,7 +7,7 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs, { Dayjs } from "dayjs";
 
 type Props = {
-  date: Dayjs;
+  date: string;
   onChange: (newValue: Dayjs | null) => void;
 };
 

--- a/frontend/src/types/VrcEventCalenderType.ts
+++ b/frontend/src/types/VrcEventCalenderType.ts
@@ -1,5 +1,3 @@
-import { Dayjs } from "dayjs";
-
 export type AvailablePlatformType = "PC" | "Quest" | "PC&Quest";
 
 export type EventGenreType = {
@@ -28,7 +26,7 @@ export type EventGenreType = {
 export type VrcEventCalenderType = {
   eventName: string;
   availablePlatform: AvailablePlatformType;
-  date: Dayjs;
+  date: string;
   startTime: string;
   endTime: string;
   eventOwner: string;


### PR DESCRIPTION
## やったこと

- dateの型をstringに変更

- createVrcEventCalenderUrl.tsで、URLSearchParamsを使ってURLを生成するコードを書きたい都合があり、Dayjs型よりもString型の方が都合が良いため、型を変更。


## とくに見て欲しいところ

-

## 動作確認したこと

-
