### PR TITLE
availablePlatformの値を変更する

### DIFF
--- a/frontend/src/component/VrcEventCalenderUrlGenerator/index.tsx
+++ b/frontend/src/component/VrcEventCalenderUrlGenerator/index.tsx
@@ -22,7 +22,7 @@ export const VrcEventCalenderUrlGenerator = () => {
 
   const initialValues: VrcEventCalenderType = {
     eventName: "エンジニア作業飲み集会",
-    availablePlatform: "PC&Quest",
+    availablePlatform: "PC/Quest両対応（Quest対応）",
     date: dayjs().format("YYYY-MM-DD"),
     startTime: "22:00",
     endTime: "23:30",

--- a/frontend/src/component/VrcEventCalenderUrlGenerator/parts/AvailablePlatform.tsx
+++ b/frontend/src/component/VrcEventCalenderUrlGenerator/parts/AvailablePlatform.tsx
@@ -20,8 +20,8 @@ export const AvailablePlatform = ({ initialValue, onChange }: Props) => {
           <MuiCheckbox
             name={"PCオンリー"}
             value={"PCオンリー"}
-            checked={initialValue === "PC"}
-            onChange={() => onChange("PC")}
+            checked={initialValue === "PCオンリー"}
+            onChange={() => onChange("PCオンリー")}
           />
         }
         label={"PCオンリー"}
@@ -31,8 +31,8 @@ export const AvailablePlatform = ({ initialValue, onChange }: Props) => {
           <MuiCheckbox
             name={"PC/Quest両対応（Quest対応）"}
             value={"PC/Quest両対応（Quest対応）"}
-            checked={initialValue === "PC&Quest"}
-            onChange={() => onChange("PC&Quest")}
+            checked={initialValue === "PC/Quest両対応（Quest対応）"}
+            onChange={() => onChange("PC/Quest両対応（Quest対応）")}
           />
         }
         label={"PC/Quest両対応（Quest対応）"}
@@ -42,8 +42,8 @@ export const AvailablePlatform = ({ initialValue, onChange }: Props) => {
           <MuiCheckbox
             name={"Quest オンリー"}
             value={"Quest オンリー"}
-            checked={initialValue === "Quest"}
-            onChange={() => onChange("Quest")}
+            checked={initialValue === "Quest オンリー"}
+            onChange={() => onChange("Quest オンリー")}
           />
         }
         label={"Quest オンリー"}

--- a/frontend/src/types/VrcEventCalenderType.ts
+++ b/frontend/src/types/VrcEventCalenderType.ts
@@ -1,4 +1,7 @@
-export type AvailablePlatformType = "PC" | "Quest" | "PC&Quest";
+export type AvailablePlatformType =
+  | "PCオンリー"
+  | "Quest オンリー"
+  | "PC/Quest両対応（Quest対応）";
 
 export type EventGenreType = {
   // アバター試着会


### PR DESCRIPTION
## やったこと

- availablePlatformの値を変更する
- convertAvailablePlatformForUrl関数を消すために、availablePlatformの値を変更する
- createUrlParamsで値を処理するときに、値を変換する必要がなくなる。

## とくに見て欲しいところ

-

## 動作確認したこと

-
